### PR TITLE
bump gpu-operator to 25.10.1 to support ubuntu24

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -36,7 +36,7 @@ gpu:
   # chartPath: deployments/gpu-operator
   chartPath:
   enabled: true
-  version: v24.9.0
+  version: v25.10.1
   config:
     # this is early-access, however it avoids a major pitfall
     # Without it, it's impossible to upgrade the underlying OS without downtime on ALL gpu nodes/workstations!

--- a/deployments/on-prem-sig/gpu/README.md
+++ b/deployments/on-prem-sig/gpu/README.md
@@ -4,7 +4,7 @@
 
 - **[drivers-preinstalled](drivers-preinstalled.yaml)**: Use this configuration if you have pre-installed NVIDIA drivers on your nodes. This removes the need to provision and install the drivers dynamically via the operator. This does mean you have to keep the drivers up to date manually.
 - **[auto-install-drivers](auto-install-drivers.yaml)**: Use this configuration if you want the NVIDIA GPU Operator to automatically install the drivers for you. This is recommended for environments that are dynamically provisioning new Nodes on the fly. Otherwise, pre-installed is usually better. Some distributions may not support this. It is normally recommended to use the pre-installed drivers for these distributions.
-- **[k3s](k3s.yaml)**: Use this configuration if you run k3s. You can pass it together with one of the other configs.
+- **[k3s](k3s.yaml)**: Use this configuration if you run k3s. You can pass it together with one of the other configs. If you are deploying a fresh k3s cluster, we recommend you instead use our [pre-packaged installer with correct defaults](https://juno-fx.github.io/Orion-Documentation/installation/quick-start/)
 
 ## Examples
 
@@ -20,6 +20,15 @@ helm install juno ./chart/ \
 ```shell
 helm install juno ./chart/ \
   -f ./deployments/on-prem-sig/gpu/auto-install-drivers.yaml \
+  ...
+  -f ./.values.yaml
+```
+
+**K3s cluster provisioned outside the recommended installer**
+```shell
+helm install juno ./chart/ \
+  -f ./deployments/on-prem-sig/gpu/auto-install-drivers.yaml \
+  -f ./deployments/on-prem-sig/gpu/k3s.yaml \
   ...
   -f ./.values.yaml
 ```

--- a/deployments/on-prem-sig/gpu/k3s.yaml
+++ b/deployments/on-prem-sig/gpu/k3s.yaml
@@ -1,0 +1,6 @@
+toolkit:
+  env:
+    - name: CONTAINERD_CONFIG
+      value: /var/lib/rancher/k3s/agent/etc/containerd/config.toml
+    - name: CONTAINERD_SOCKET
+      value: /run/k3s/containerd/containerd.sock

--- a/helper/install.sh
+++ b/helper/install.sh
@@ -26,7 +26,7 @@ GENESIS_VERSION="${GENESIS_VERSION:-v1.7.1}"
 INGRESS_REPO_URL="${INGRESS_REPO_URL:-https://kubernetes.github.io/ingress-nginx}"
 INGRESS_VERSION="${INGRESS_VERSION:-4.12.1}"
 GPU_REPO_URL="${GPU_REPO_URL:-https://helm.ngc.nvidia.com/nvidia}"
-GPU_VERSION="${GPU_VERSION:-v24.9.0}"
+GPU_VERSION="${GPU_VERSION:-v25.10.1}"
 
 # Hostname (always ask, show system default as suggested value)
 SYSTEM_HOST="$(hostname -f)"

--- a/values.yaml
+++ b/values.yaml
@@ -86,7 +86,7 @@ genesis:
 # https://github.com/NVIDIA/gpu-operator/blob/main/deployments/gpu-operator/values.yaml
 #gpu:
 #  url: "https://helm.ngc.nvidia.com/nvidia"
-#  version: v24.9.0
+#  version: v25.10.1
 #  Map override values to the following config key
 #  config:
 #    # Uncomment this to pull from a local registry.


### PR DESCRIPTION
Currently ubuntu24 will fail to install drivers.
For customers that wish to use it, we must bump it.

I already did some practical validation on this on AWS - I can run a gpu workload:

```
root@ip-172-31-82-31:/home/ubuntu# kubectl get pods
NAME             READY   STATUS      RESTARTS   AGE
cuda-vectoradd   0/1     Completed   0          12s
root@ip-172-31-82-31:/home/ubuntu# cat yolo.yaml 
apiVersion: v1
kind: Pod
metadata:
  name: cuda-vectoradd
spec:
  restartPolicy: OnFailure
  containers:
  - name: cuda-vectoradd
    image: "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubuntu20.04"
    resources:
      limits:
        nvidia.com/gpu: 1

```
We'll also need to make sure the OneClick sets the containerd path for k3s.

I'd rather force that in the juno_k3s role instead of here. I'll bump the change there.

